### PR TITLE
docs: fix markdown

### DIFF
--- a/docs/howto/common-deps-with-multiple-pypi-versions.md
+++ b/docs/howto/common-deps-with-multiple-pypi-versions.md
@@ -43,8 +43,6 @@ rules_python_config.add_transition_setting(
 
 # File: BUILD.bazel
 
-```bzl
-
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 string_flag(


### PR DESCRIPTION
There's an extra code block open tag that gets highlighted as an error on readthedocs.
<img width="363" height="186" alt="Screenshot 2025-11-18 at 14 05 02" src="https://github.com/user-attachments/assets/7cf7e2ce-48b1-4765-ab79-d892605a5b97" />
